### PR TITLE
docs: add documentation to packages and devcontainer extensions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,18 @@
 {
-  "customizations": {},
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "Continue.continue",
+        "ms-python.vscode-python-envs",
+        "ms-python.debugpy",
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "oderwat.indent-rainbow",
+        "Gruntfuggly.todo-tree",
+        "yzhang.markdown-all-in-one"
+      ]
+    }
+  },
   "dockerComposeFile": [
     "../docker-compose.yml",
     "dev.docker-compose.yml"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# INIT - Python
+# INITpy – A Bare‑Bone Python Project Template
 
 [![release: 0.7.0](https://img.shields.io/badge/rel-0.7.0-blue.svg?style=flat-square)](https://github.com/artdotlis/INITpy)
 [![The Unlicense](https://img.shields.io/badge/License-Unlicense-brightgreen.svg?style=flat-square)](https://choosealicense.com/licenses/unlicense/)
@@ -6,17 +6,78 @@
 
 [![main](https://github.com/artdotlis/INITpy/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/artdotlis/INITpy/actions/workflows/main.yml)
 
+> **A minimal, opinionated, and fully‑automated Python project layout.**
+
 ---
 
-Initial bare-bone Python project.
+## 🛠️ Development Workflow
 
-## Requirements (development)
+### 1. Dev Container (Optional)
 
-### Default
+The project ships with a Docker‑Compose powered dev container. It automatically installs all dev dependencies - ideal for a consistent and sandboxed development environment.
 
-- GNU/Linux
+Inside the container you can use the `make` targets as below.
 
-### Dev Container
+### 2. Makefile Targets
 
-- Docker
-- Docker - Compose
+| Target            | Purpose |
+|-------------------|---------|
+| `dev`             | Sets up the development environment, installs the frozen dependency set, and installs the git hooks. |
+| `tests`           | Synchronises the test‑only dependency set. |
+| `build`           | Synchronises the build‑time dependency set. |
+| `docs`            | Synchronises the docs‑only dependency set. |
+| `setup`           | Installs **uv**, the specified Python version, creates a relocatable virtual environment, and upgrades pip. |
+| `runAct`          | Activates the `.venv` and cleans a temporary file. |
+| `runChecks`       | Runs the pre‑commit hook suite (`lefthook run pre-commit`). |
+| `runDocs`         | Builds the MkDocs site (using the dev configuration). |
+| `serveDocs`       | Serves the MkDocs site locally. |
+| `runTests`        | Executes the test suite via **tox**. |
+| `runBuild`        | Builds the declared packages (`pkg1`, `shared_utils`). |
+| `runBump`         | Bumps the version with **cz** and commits the change. |
+| `runUV`           | Executes an arbitrary `uv` command passed in `CMD`. |
+| `runLock / runUpdate` | Exports the frozen dependency set to `requirements.txt` files for each package/group and locks the environment. Also updates the dependencies in `runUpdate`. |
+| `com commit`      | Generates a Conventional Commit message (via ollama or `cz`), validates it, and commits. |
+| `recom recommit`  | Commits the previously generated message (again validating with `cz`). |
+
+> **Important** – the Makefile is guarded by `ifeq ($(CONTAINER),container)`; if `CONTAINER` is not set to `container` the make process aborts with an error.  
+> To run the targets, set the variable on the command line, e.g. `make CONTAINER=container dev`, or run it from inside the dev container.
+
+---
+
+## 📚 Documentation
+
+The full API documentation is built with **MkDocs** and automatically deployed to GitHub Pages.
+
+```bash
+# Build the site into the `public/` folder
+make runDocs
+```
+
+You can preview the documentation locally while you work:
+
+```bash
+# Start a lightweight development server
+make serveDocs
+```
+
+Open `http://localhost:8000` to explore.
+
+---
+
+## 🚀 Features
+
+- **Zero‑configuration** – All tooling, dependencies, and build settings are declared in a single `pyproject.toml` file.
+- **Monorepo‑friendly** – The layout supports multiple packages in a single repository, making it ideal for mono‑repo workflows.
+- **Modern tooling** – Linting, formatting, static analysis, and security checks are handled by `black`, `ruff`, and `mypy`.
+- **Testing** – Automated tests run with `tox`, and coverage reports are generated automatically.
+- **Packaging** – Distribution follows PEP 621; the project can be built and published via `uv` or `pip`.
+- **Documentation** – MkDocs generates a fully‑static site from Markdown; it can be previewed locally or published to GitHub Pages.
+- **Containerised development** – A Docker‑Compose dev container replicates the CI environment, ensuring consistent tool versions.
+- **License** – The project is released into the public domain under the Unlicense.
+
+---
+
+## 📜 License
+
+This project is licensed under the [Unlicense](https://choosealicense.com/licenses/unlicense/).  
+Feel free to use, modify, and distribute it without any restrictions.

--- a/packages/pkg1/README.md
+++ b/packages/pkg1/README.md
@@ -1,0 +1,62 @@
+# pkg1
+
+**An example package that lives inside the INITpy monorepo.**
+
+---
+
+## 📦 About
+
+`pkg1` is one of the first‑level projects bundled in the repository.  
+It demonstrates how a standalone application can depend on the
+internal `shared_utils` library and expose a console script entry
+point (`pkg1`).
+
+Because it is part of a monorepo, the package is **private** – it
+should not be published to PyPI – and is built along with the other
+packages via the `uv` build system.
+
+---
+
+## 📚 Installation & Build
+
+The package is automatically built when you run:
+
+```bash
+# From the repository root
+make runBuild
+```
+
+There is no separate `pip install` step for consuming `pkg1` from
+outside this repo; it is included in the repository’s wheel
+distribution.
+
+If you add external dependencies, declare them in the root
+`pyproject.toml` or in this sub‑module’s `[project.dependencies]`.
+
+---
+
+## ⚙️ Usage
+
+### Console script
+
+```bash
+# From the repository root (or any virtual‑env that has the repo’s
+# packages on `sys.path`):
+pkg1
+```
+
+Running the script will execute `pkg1.main:run`.
+
+### Importing in code
+
+```python
+from pkg1.main import run
+```
+
+---
+
+## 📚 Modules
+
+| Module | Description |
+|--------|-------------|
+| `pkg1.main` | The application’s main entry point; it coordinates the work performed by `pkg1` and pulls in helpers from `shared_utils`. |

--- a/packages/pkg1/src/pkg1/main.py
+++ b/packages/pkg1/src/pkg1/main.py
@@ -3,19 +3,31 @@ from shared_utils.hello import main
 
 
 class MyMain:
-    """_summary_"""
+    """Main class for pkg1.
+
+    This class serves as the entry point for pkg1 functionality.
+    It demonstrates how the package can coordinate different
+    components (e.g., sub modules and external utilities).
+    """
 
     def method_main(self, inp: str, /) -> None:
-        """_summary_
+        """Print the supplied message.
 
         Args:
-            inp (str): _description_
+            inp (str): The message to print to stdout.
         """
         print(inp)
 
 
 def run() -> None:
-    MyMain().method_main(" ".join(MySub().method_sub(["Hello", "world", "!"])))
+    """Execute the demo flow of pkg1.
+
+    The function joins a static list of words via :class:`MySub`,
+    passes the resulting string to :class:`MyMain`, and finally
+    calls the :func:`main` function from ``shared_utils.hello``.
+    """
+    message = " ".join(MySub().method_sub(["Hello", "world", "!"]))
+    MyMain().method_main(message)
     main()
 
 

--- a/packages/pkg1/src/pkg1/sub/sub.py
+++ b/packages/pkg1/src/pkg1/sub/sub.py
@@ -1,13 +1,24 @@
 class MySub:
-    """_summary_"""
+    """Utility helper that simply echoes a list of strings.
+
+    This lightweight class demonstrates how a sub-package can expose
+    small building blocks that other parts of the application (or
+    external consumers) can use.
+    """
 
     def method_sub(self, arg: list[str], /) -> list[str]:
-        """_summary_
+        """Return the supplied list unchanged.
 
         Args:
-            arg (list[str]): _description_
+            arg (list[str]): A list of strings that will be returned
+                verbatim.
 
         Returns:
-            list[str]: _description_
+            list[str]: The same list that was passed in.
+
+        Notes:
+            This method does not modify the input list and simply
+            forwards it. It exists only to provide a concrete
+            implementation for the ``pkg1.main`` module to call.
         """
         return arg

--- a/packages/shared_utils/README.md
+++ b/packages/shared_utils/README.md
@@ -1,0 +1,27 @@
+# shared_utils
+
+**Shared utility library for all the packages in this repository.**
+
+---
+
+## 📦 About
+
+`shared_utils` is a lightweight, internal library that provides a common set of helper functions, data‑structures, and utilities used across the various top‑level packages in the repository. It is **private** – not intended to be uploaded to PyPI – and is bundled with the main project via the `uv` monorepo build system.
+
+---
+
+## 📚 Installation
+
+The library is automatically built and packaged when you run `make runBuild` from the repository root. There is no separate installation step required for consuming code in this mono‑repo.
+
+If you need to add dependencies to the shared library, add them under the `[project.dependencies]` section of the root `pyproject.toml` or in this sub‑module’s `pyproject.toml`.
+
+---
+
+## ⚙️ Usage
+
+Import the module from your packages:
+
+```python
+from shared_utils import <function_or_class>
+```

--- a/packages/shared_utils/src/shared_utils/hello.py
+++ b/packages/shared_utils/src/shared_utils/hello.py
@@ -1,2 +1,8 @@
 def main() -> None:
+    """Prints a simple greeting from the shared utilities package.
+
+    This function is intended as a lightweight demo to show that the `shared_utils`
+    sub-package is correctly installed and importable from other packages
+    in the monorepo.
+    """
     print("Hello from shared!")


### PR DESCRIPTION
Add documentation to package `pkg1` and a shared utility library `shared_utils`.  Update the development container configuration to install a set of VSCode extensions that aid Python development. Extend the root README with an expanded description of the project structure, Makefile targets, and documentation workflow.