### PR TITLE
chore(ruff): add missing pydocstyle ignore rules and docs selection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,8 +134,8 @@ exclude = [
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 fixable = ["A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "EM", "ERA", "EXE", "FBT", "ICN", "INP", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PTH", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "TRY", "UP", "YTT"]
-ignore = ["TRY003", "N818"]
-select = ["E", "F", "B", "C90", "S", "PT", "ARG", "PTH", "TRY", "RUF", "N"]
+ignore = ["TRY003", "N818", "D100", "D101", "D102", "D103", "D104", "D105", "D106", "D107"]
+select = ["E", "F", "B", "C90", "S", "PT", "ARG", "PTH", "TRY", "RUF", "N", "D", "DOC"]
 unfixable = []
 
 [tool.ruff.lint.mccabe]
@@ -143,6 +143,9 @@ max-complexity = 11
 
 [tool.ruff.lint.pylint]
 max-args = 8
+
+[tool.ruff.pydocstyle]
+convention = "google"
 
 [tool.tox]
 requires = ["tox>=4.23"]


### PR DESCRIPTION
Add ignore rules for D100‑D107 to suppress missing docstring warnings, include DOC in the select list, and enable google convention for pydocstyle. This updates the pyproject.toml lint configuration to be more strict on documentation quality and align with project style guidelines.